### PR TITLE
Aggiunto la mia pagina di presentazione e aggiunto una sezione in configurazione jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # SITE CONFIGURATION
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://example.com" # the base hostname & protocol for your site
+url: "http://jugtorino.it/" # the base hostname & protocol for your site
+exclude: ["CNAME", "README.md", "LICENSE"]
 
 # THEME-SPECIFIC CONFIGURATION
 theme:

--- a/pages/m_people.md
+++ b/pages/m_people.md
@@ -9,3 +9,4 @@ permalink: /people/
 
 [Simone Bordet](simonebordet/)
 
+[Luigi R. Viggiano](luigiviggiano/)

--- a/pages/people/luigiviggiano/LuigiViggiano.md
+++ b/pages/people/luigiviggiano/LuigiViggiano.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Luigi R. Viggiano
+hide: true
+permalink: /people/luigiviggiano/
+---
+
+<div style="text-align: center; padding-bottom: 20px">
+<a href="https://github.com/lviggiano/"><i class="fa fa-fw fa-github"></i></a>
+<a href="mailto:luigi.viggiano@gmail.com"><i class="fa fa-fw fa-envelope"></i></a>
+<a href="skype:luigi.viggiano?chat"><i class="fa fa-skype"></i></a>
+<a href="https://www.linkedin.com/in/viggiano"><i class="fa fa-fw fa-linkedin"></i></a>
+<a href="http://stackoverflow.com/users/258289/luigi-r-viggiano"><i class="fa fa-fw fa-stack-overflow"></i></a>
+<a href="http://en.newinstance.it/"><i class="fa fa-fw fa-wordpress"></i></a>
+<a href="https://twitter.com/lviggiano/"><i class="fa fa-fw fa-twitter"></i></a>
+<a href="https://www.facebook.com/luigi.viggiano.94"><i class="fa fa-fw fa-facebook"></i></a>
+<a href="https://www.flickr.com/photos/lviggiano/"><i class="fa fa-fw fa-flickr"></i></a>
+<a href="http://www.luigiviggiano.photography"><i class="fa fa-fw fa-camera"></i></a>
+</div>
+
+Ciao mi chiamo Luigi, e sono un fiero membro del JUG Torino, fin dagli albori.
+
+Un progettino open source che (pigramente) gestisco è questo qui: [OWNER API](http://owner.aeonbits.org).
+
+Programmatore per passione, fotografo per diletto. Pessimo elemento per natura.


### PR DESCRIPTION
Ho aggiunto la mia pagina di presentazione. L'ho chiamata `LuigiViggiano.md` per evitare di avere tutte le pagine denominate come `index.md`, che poi nell'IDE è un casino, tanto fa fede la direttiva nell'header del file markdown:

```
permalink: /people/luigiviggiano/
```

Secondo me è una buona idea evitare di avere tutte le pagine nominate come `index.md` ma usare nomi significativi. Tra l'altro credo che anche la directory in cui vengono contenute non deve necessariamente combaciare con l'URL (ma non ne sono sicuro al 100%).

In `_config.yml` ho aggiunto una lista di file da escludere dall'essere esportati su web.

Ho aggiunto anche il `.gitignore` che male non fa, spero.
