### PR TITLE
Puntamento errato

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### [JUG Torino](http://jugtorino.it) Website
+### [JUG Torino](https://jugtorino.org) Website
 
 ### Build status: [![Build Status](https://travis-ci.org/jugtorino/jugtorino.github.io.svg?branch=master)](https://travis-ci.org/jugtorino/jugtorino.github.io)
 


### PR DESCRIPTION
Ciao

Il readme puntava a jugtorino.it e non jugtorino.org, non vorrei sbagliarmi, ma è un errore

ciao
matteo